### PR TITLE
fix: block invalidation was broken due to previous refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "watch-ts": "lerna exec --parallel -- yarn run watch-ts",
     "build-ts": "lerna exec --parallel -- yarn run build-ts",
+    "test": "lerna exec --parallel --scope @xlnt/gnarly-core -- yarn run test",
     "pkg": "lerna run pkg --scope=@xlnt/gnarly-bin",
     "docker-build": "docker build -t shrugs/gnarly-test:demo .",
     "docker-push": "docker push shrugs/gnarly-test:demo",

--- a/packages/gnarly-core/src/ReducerRunner.ts
+++ b/packages/gnarly-core/src/ReducerRunner.ts
@@ -64,6 +64,7 @@ class ReducerRunner {
             // let's re-hydrate local state by replaying transactions
             await this.ourbit.resumeFromTxId(latestBlockHash)
           } catch (error) {
+            latestBlockHash = null
             this.debug('No latest transaction, so we\'re definitely starting from scratch')
           }
         } else {
@@ -77,6 +78,7 @@ class ReducerRunner {
         throw new Error(`Unexpected ReducerType ${this.reducer.config.type}`)
     }
 
+    this.debug('Streaming blocks from %s', latestBlockHash || 'HEAD')
     // and now ingest blocks from latestBlockHash
     await this.blockstreamer.start(latestBlockHash)
 

--- a/packages/gnarly-core/src/ourbit/Ourbit.ts
+++ b/packages/gnarly-core/src/ourbit/Ourbit.ts
@@ -37,7 +37,7 @@ import {
  *    - ourbit = new Ourbit(targetState, store, persistPatch)
  *    - ourbit.resumeFromTxId(txId = null)
  *    - ourbit.processTransaction(txId, operation producer)
- *    - ourbit.rollbackTransaction(txId)
+ *    - ourbit.rollbackTransaction(blockHash)
  */
 class Ourbit {
   constructor (
@@ -105,8 +105,8 @@ class Ourbit {
    * @TODO(shrugs) - make this a "fix-forward" operation and include event log
    * @param txId transaction id
    */
-  public rollbackTransaction = async (txId: string) => {
-    const tx = await globalState.store.getTransaction(this.key, txId)
+  public rollbackTransaction = async (blockHash: string) => {
+    const tx = await globalState.store.getTransactionByBlockHash(this.key, blockHash)
     await this.uncommitTransaction(tx)
   }
 

--- a/packages/gnarly-core/src/stores/index.ts
+++ b/packages/gnarly-core/src/stores/index.ts
@@ -11,6 +11,7 @@ export interface IPersistInterface {
   deleteTransaction (reducerKey: string, tx: ITransaction): Promise<any>
   saveTransaction (reducerKey: string, tx: ITransaction): Promise<any>
   getTransaction (reducerKey: string, txId: string): Promise<ITransaction>
+  getTransactionByBlockHash (reducerKey: string, blockHash: string): Promise<ITransaction>
 
   // event log CRUD actions
 

--- a/packages/gnarly-core/test/Ourbit.spec.ts
+++ b/packages/gnarly-core/test/Ourbit.spec.ts
@@ -146,7 +146,7 @@ describe('Ourbit', () => {
 
     await ourbit.processTransaction('0x2', async () => {
       targetState.key = 'newValue'
-    }, { blockHash: tx.blockHash })
+    }, { blockHash: '0x2' })
 
     await ourbit.rollbackTransaction('0x2')
     targetState.should.deep.equal({ key: 'value' })
@@ -160,7 +160,7 @@ describe('Ourbit', () => {
 
     const newState = {}
     // new state, same store
-    const newOurbit = new Ourbit(TEST_KEY, newState, persistPatch)
+    const newOurbit = new Ourbit(TEST_KEY, newState, persistPatch, context)
 
     await newOurbit.resumeFromTxId('0x1')
     newState.should.deep.equal({ key: 'value' })

--- a/packages/gnarly-core/test/helpers/MockPersistInterface.ts
+++ b/packages/gnarly-core/test/helpers/MockPersistInterface.ts
@@ -53,6 +53,10 @@ class MockPersistInterface implements IPersistInterface {
   public async getTransaction (reducerKey: string, txId: string): Promise<ITransaction> {
     return _.find(this.transactions, (t) => t.id === txId)
   }
+
+  public async getTransactionByBlockHash (reducerKey: string, blockHash: string): Promise<ITransaction> {
+    return _.find(this.transactions, (t) => t.blockHash === blockHash)
+  }
 }
 
 export default MockPersistInterface

--- a/packages/gnarly-reducer-erc721/src/models/sequelize.ts
+++ b/packages/gnarly-reducer-erc721/src/models/sequelize.ts
@@ -10,15 +10,19 @@ const sequelizeModels = (
   const { Patch } = makeGnarlyModels(Sequelize, sequelize)
   // ownerOf table
   const ERC721Tokens = sequelize.define('erc721_tokens', {
-    darAddress: { type: DataTypes.STRING, primaryKey: true },
-    tokenId: { type: DataTypes.STRING, primaryKey: true },
+    id: { type: DataTypes.STRING, primaryKey: true },
+    darAddress: { type: DataTypes.STRING },
+    tokenId: { type: DataTypes.STRING },
 
     // 1:1 properties of token
     owner: { type: DataTypes.STRING },
   }, {
       indexes: [
+        // composite unique constraint on darAddress x tokenId
+        { unique: true, fields: ['darAddress', 'tokenId'] },
+        // fast lookups of tokens by darAddress
         { fields: ['darAddress'] },
-        { fields: ['tokenId'] },
+        // fast lookups by owner across dars
         { fields: ['owner'] },
       ],
     })
@@ -38,14 +42,10 @@ const sequelizeModels = (
 
   // token has many owners
   ERC721Tokens.hasMany(ERC721TokenOwners, {
-    foreignKey: 'tokenId',
-    sourceKey: 'tokenId',
     as: 'Owners',
   })
 
   ERC721TokenOwners.belongsTo(ERC721Tokens, {
-    foreignKey: 'tokenId',
-    targetKey: 'tokenId',
     as: 'Token',
   })
 

--- a/packages/gnarly-reducer-erc721/src/reducer.ts
+++ b/packages/gnarly-reducer-erc721/src/reducer.ts
@@ -49,6 +49,7 @@ const makeReducer = (
   interface IERC721Tracker {
     tokens: { // 1:1
       [id: string]: {
+        id: string,
         tokenId: string,
         darAddress: string,
         owner: string,
@@ -60,7 +61,10 @@ const makeReducer = (
     transfer: (tokenId: string, from: string, to: string) => {
       debug('transferring token %s to %s', tokenId, to)
 
-      const existing = state.tokens[tokenId]
+      // hacky composite key for O(n) lookups required by JSON-Patch
+      const id = `${darAddress}-${tokenId}`
+
+      const existing = state.tokens[id]
       if (existing) {
         // push
         existing.owner = to
@@ -72,7 +76,7 @@ const makeReducer = (
         // init
         // order-dependent because of foreign key
         operation(() => {
-          state.tokens[tokenId] = { tokenId, darAddress, owner: to }
+          state.tokens[id] = { id, tokenId, darAddress, owner: to }
         })
         emit(appendTo('owners', {
           tokenId,


### PR DESCRIPTION
fixes #21 

two reasons:
1) we were previously using the blockHash as a txid, but that assumption
was broken in a previous refactor, so now we need a "lookup by blockhash"
function for finding txs
2) reverts for 721 should never have worked because they used a
compoaistecomposite primary key, which doesn't play well with
json patch, so a pseudo composite primary key was used instead by
concatenating the two previous composite keys and then adding the
appropriate composite unique constraint for the same functionality.