### PR TITLE
fix: use monotonically increasing ids to guarantee operation execution order

### DIFF
--- a/packages/gnarly-core/src/ReducerRunner.ts
+++ b/packages/gnarly-core/src/ReducerRunner.ts
@@ -57,15 +57,25 @@ class ReducerRunner {
           // we're resuming, so replay from store if possible
           try {
             const latestTransaction = await globalState.store.getLatestTransaction(this.reducer.config.key)
-            latestBlockHash = latestTransaction ? latestTransaction.blockHash : null
+            if (!latestTransaction) {
+              throw new Error('No latest transaction available.')
+            }
 
-            this.debug('Attempting to reload state from %s', latestBlockHash || 'HEAD')
+            latestBlockHash = latestTransaction.blockHash
 
-            // let's re-hydrate local state by replaying transactions
-            await this.ourbit.resumeFromTxId(latestBlockHash)
+            try {
+              // let's re-hydrate local state by replaying transactions
+              this.debug('Attempting to reload state from %s', latestTransaction.id || 'HEAD')
+              await this.ourbit.resumeFromTxId(latestTransaction.id)
+            } catch (error) {
+              // we weren't able to replace state, which means something is totally broken
+              this.debug(error)
+              process.exit(1)
+            }
           } catch (error) {
+            this.debug(error)
             latestBlockHash = null
-            this.debug('No latest transaction, so we\'re definitely starting from scratch')
+            this.debug('No latest transaction, so we\'re definitely starting from scratch.')
           }
         } else {
           // we reset, so let's start from HEAD

--- a/packages/gnarly-core/src/ReducerRunner.ts
+++ b/packages/gnarly-core/src/ReducerRunner.ts
@@ -73,7 +73,6 @@ class ReducerRunner {
               process.exit(1)
             }
           } catch (error) {
-            this.debug(error)
             latestBlockHash = null
             this.debug('No latest transaction, so we\'re definitely starting from scratch.')
           }

--- a/packages/gnarly-core/src/ourbit/Ourbit.ts
+++ b/packages/gnarly-core/src/ourbit/Ourbit.ts
@@ -128,9 +128,6 @@ class Ourbit {
         totalPatches += tx.patches.length
         this.debug('[applyPatch] %s %d', tx.id, tx.patches.length)
         const allOperations = operationsOfPatches(tx.patches)
-        this.debug('batch: %j', txBatch)
-        this.debug('patches:', JSON.stringify(tx.patches))
-        this.debug('operations:', JSON.stringify(allOperations))
         applyPatch(this.targetState, allOperations.map(toOperation))
       })
     }

--- a/packages/gnarly-core/src/stores/sequelize.ts
+++ b/packages/gnarly-core/src/stores/sequelize.ts
@@ -199,7 +199,7 @@ class SequelizePersistInterface implements IPersistInterface {
       order: [
         ['mid', 'ASC'],
         [{ model: this.Patch }, 'mid', 'ASC'],
-        [{ model: this.Patch }, 'mid', 'ASC'],
+        [{ model: this.Patch }, { model: this.Operation }, 'mid', 'ASC'],
       ],
     }
 
@@ -262,7 +262,7 @@ class SequelizePersistInterface implements IPersistInterface {
         }],
         order: [
           [{ model: this.Patch }, 'mid', 'ASC'],
-          [{ model: this.Operation }, 'mid', 'ASC'],
+          [{ model: this.Patch }, { model: this.Operation }, 'mid', 'ASC'],
         ],
         rejectOnEmpty: true,
       })).get({ plain })

--- a/packages/gnarly-core/src/stores/sequelize.ts
+++ b/packages/gnarly-core/src/stores/sequelize.ts
@@ -19,6 +19,7 @@ export const makeSequelizeModels = (
 
   const Transaction = sequelize.define('transaction', {
     id: { type: DataTypes.STRING, primaryKey: true },
+    mid: { type: DataTypes.INTEGER, autoIncrement: true },
     blockHash: { type: DataTypes.STRING },
   }, {
     indexes: [
@@ -28,9 +29,11 @@ export const makeSequelizeModels = (
 
   const Patch = sequelize.define('patch', {
     id: { type: DataTypes.STRING, primaryKey: true },
+    mid: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
   })
 
   const Operation = sequelize.define('operation', {
+    mid: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
     path: { type: DataTypes.STRING },
     op: { type: DataTypes.JSONB },
     value: { type: DataTypes.JSONB },
@@ -160,7 +163,7 @@ class SequelizePersistInterface implements IPersistInterface {
   public getLatestTransaction = async (reducerKey: string): Promise<ITransaction> => {
     try {
       return (await this.Transaction.findOne({
-        order: [['createdAt', 'DESC']],
+        order: [['mid', 'DESC']],
         rejectOnEmpty: true,
         include: [{
           model: this.Reducer,
@@ -178,12 +181,11 @@ class SequelizePersistInterface implements IPersistInterface {
     try {
       initial = await this.getPlainTransaction(reducerKey, toTxId)
     } catch (error) {
-      throw new Error(`Could not find txId ${toTxId} - ${error.stack}`)
+      throw new Error(`Could not find txId ${toTxId} in ${reducerKey} - ${error.stack}`)
     }
 
     const query = {
-      where: { createdAt: { [this.Sequelize.Op.lte]: initial.createdAt } },
-      order: [['createdAt', 'ASC']],
+      where: { mid: { [this.Sequelize.Op.lte]: initial.mid } },
       include: [{
         model: this.Patch,
         include: [{
@@ -194,6 +196,11 @@ class SequelizePersistInterface implements IPersistInterface {
         model: this.Reducer,
         where: { id: { [this.Sequelize.Op.eq]: reducerKey } },
       }],
+      order: [
+        ['mid', 'ASC'],
+        [{ model: this.Patch }, 'mid', 'ASC'],
+        [{ model: this.Patch }, 'mid', 'ASC'],
+      ],
     }
 
     return batch(this.Transaction, query, 1000, (txs) => txs.map(
@@ -253,6 +260,10 @@ class SequelizePersistInterface implements IPersistInterface {
           model: this.Reducer,
           where: { id: { [this.Sequelize.Op.eq]: reducerKey } },
         }],
+        order: [
+          [{ model: this.Patch }, 'mid', 'ASC'],
+          [{ model: this.Operation }, 'mid', 'ASC'],
+        ],
         rejectOnEmpty: true,
       })).get({ plain })
     } catch (error) {


### PR DESCRIPTION
Operation order wasn't being preserved because I naively used `createdAt` to guarantee order, but operations are committed within the same nanosecond and batching perhaps causes that to mess up as well.

We switched to using monotonically increasing identifiers (`mid`) on models that need this behavior.

Also added a try-catch that checks to make sure state resumptions work; if this catch gets executed, something disastrous happened and the set of patches in the database doesn't produce a valid internal state.